### PR TITLE
feat: add session linking to track which sessions work on issues

### DIFF
--- a/modules/hook-issue-session-end/README.md
+++ b/modules/hook-issue-session-end/README.md
@@ -1,0 +1,67 @@
+# Issue Session-End Hook
+
+Hook that automatically marks issues when an Amplifier session ends, enabling session linking and continuity tracking.
+
+## What It Does
+
+When an Amplifier session ends with issues still `in_progress`, this hook:
+
+1. Finds all in-progress issues
+2. Checks which issues were touched by the current session
+3. Emits `session_ended` events on those issues
+
+This enables users to:
+- See which sessions were interrupted
+- Resume context later with `amplifier session resume <session_id>`
+- Track the full history of sessions that worked on an issue
+
+## Configuration
+
+```yaml
+hooks:
+  - module: hook-issue-session-end
+    source: git+https://github.com/microsoft/amplifier-bundle-issues@main#subdirectory=modules/hook-issue-session-end
+    config:
+      priority: 90      # Hook priority (default: 90, runs late)
+      enabled: true     # Whether hook is active (default: true)
+```
+
+## How It Works
+
+The hook registers on the `session:end` event and:
+
+1. Gets the current session ID from event data
+2. Finds the issue_manager tool
+3. Lists all in-progress issues
+4. For each issue, checks if events exist with the current session ID
+5. If yes, emits a `session_ended` event
+
+## Session Linking
+
+This hook works together with the session tracking in `IssueManager` to provide full session linking:
+
+- Every issue operation records the session ID in events
+- This hook marks when sessions end
+- The `get_sessions` operation retrieves all linked sessions
+
+## Example
+
+```
+Session abc123 starts
+  → Creates issue #1 (event: created, session_id: abc123)
+  → Updates issue #1 to in_progress (event: updated, session_id: abc123)
+Session abc123 ends
+  → session_ended event emitted (event: session_ended, session_id: abc123)
+
+Later, user can run:
+  issue_manager(operation='get_sessions', params={'issue_id': '#1'})
+  → Returns: {linked_sessions: ['abc123'], ...}
+  
+  amplifier session resume abc123
+  → Revives full context from that session
+```
+
+## Dependencies
+
+- `amplifier-core`
+- `amplifier-module-issue-manager`

--- a/modules/hook-issue-session-end/amplifier_module_hook_issue_session_end/__init__.py
+++ b/modules/hook-issue-session-end/amplifier_module_hook_issue_session_end/__init__.py
@@ -1,0 +1,134 @@
+"""Issue session-end hook module.
+
+Automatically marks issues when an Amplifier session ends, providing
+continuity by recording session boundaries on in-progress issues.
+"""
+
+import logging
+from typing import Any
+
+from amplifier_core import HookResult
+from amplifier_core import ModuleCoordinator
+
+logger = logging.getLogger(__name__)
+
+
+async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = None):
+    """Mount the issue session-end hook.
+
+    Args:
+        coordinator: Module coordinator
+        config: Optional configuration
+            - priority: Hook priority (default: 90, runs late to see full session)
+            - enabled: Whether hook is active (default: True)
+
+    Returns:
+        Optional cleanup function
+    """
+    config = config or {}
+    hook = IssueSessionEndHook(coordinator, config)
+    hook.register(coordinator.hooks)
+    logger.info("Mounted hook-issue-session-end")
+    return
+
+
+class IssueSessionEndHook:
+    """Hook that marks issues when an Amplifier session ends.
+
+    When a session ends with issues still in_progress, this hook emits
+    session_ended events to provide continuity. This enables users to
+    see which sessions were interrupted and resume context later.
+    """
+
+    def __init__(self, coordinator: ModuleCoordinator, config: dict[str, Any]):
+        """Initialize issue session-end hook.
+
+        Args:
+            coordinator: Module coordinator (for accessing issue state)
+            config: Configuration dict
+                - priority: Hook priority (default: 90)
+                - enabled: Whether hook is active (default: True)
+        """
+        self.coordinator = coordinator
+        self.priority = config.get("priority", 90)
+        self.enabled = config.get("enabled", True)
+
+    def register(self, hooks):
+        """Register hook on session:end event."""
+        if self.enabled:
+            hooks.register(
+                "session:end",
+                self.on_session_end,
+                priority=self.priority,
+                name="hook-issue-session-end",
+            )
+
+    async def on_session_end(self, event: str, data: dict[str, Any]) -> HookResult:
+        """Mark in-progress issues when session ends.
+
+        Args:
+            event: Event name ("session:end")
+            data: Event data with session_id
+
+        Returns:
+            HookResult - always continue (this is observational)
+        """
+        if not self.enabled:
+            return HookResult(action="continue")
+
+        session_id = data.get("session_id")
+        if not session_id:
+            logger.debug("hook-issue-session-end: No session_id in event data")
+            return HookResult(action="continue")
+
+        # Try to find the issue_manager tool
+        tools = getattr(self.coordinator, "tools", {})
+        issue_manager_tool = None
+
+        for tool_name, tool in tools.items():
+            if "issue" in tool_name.lower():
+                issue_manager_tool = tool
+                break
+
+        if not issue_manager_tool:
+            logger.debug("hook-issue-session-end: issue_manager tool not available")
+            return HookResult(action="continue")
+
+        # Get the embedded IssueManager
+        issue_manager = getattr(issue_manager_tool, "issue_manager", None)
+        if not issue_manager:
+            logger.debug("hook-issue-session-end: No embedded IssueManager found")
+            return HookResult(action="continue")
+
+        try:
+            # Find in-progress issues
+            in_progress_issues = issue_manager.list_issues(status="in_progress")
+
+            # For each in-progress issue, check if this session touched it
+            # and emit session_ended event
+            marked_count = 0
+            for issue in in_progress_issues:
+                # Get events for this issue
+                events = issue_manager.get_issue_events(issue.id)
+
+                # Check if this session touched this issue
+                session_touched = any(
+                    e.session_id == session_id for e in events
+                )
+
+                if session_touched:
+                    issue_manager.emit_session_ended(issue.id)
+                    marked_count += 1
+                    logger.debug(
+                        f"hook-issue-session-end: Marked session end on issue {issue.id}"
+                    )
+
+            if marked_count > 0:
+                logger.info(
+                    f"hook-issue-session-end: Marked {marked_count} issues with session end"
+                )
+
+        except Exception as e:
+            logger.error(f"hook-issue-session-end: Error marking issues: {e}")
+
+        return HookResult(action="continue")

--- a/modules/hook-issue-session-end/pyproject.toml
+++ b/modules/hook-issue-session-end/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "amplifier-module-hook-issue-session-end"
+version = "1.0.0"
+description = "Hook that marks issues when Amplifier sessions end for session linking"
+requires-python = ">=3.11"
+dependencies = [
+    "amplifier-core",
+    "amplifier-module-issue-manager",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_module_hook_issue_session_end"]

--- a/modules/issue-manager/amplifier_module_issue_manager/models.py
+++ b/modules/issue-manager/amplifier_module_issue_manager/models.py
@@ -105,18 +105,20 @@ class IssueEvent:
     """Event record for issue changes.
 
     Tracks all modifications to issues for audit and observability.
+    Includes session_id for linking issues to Amplifier sessions.
     """
 
     id: str
     issue_id: str
-    event_type: str  # created|updated|closed|blocked|unblocked
+    event_type: str  # created|updated|closed|blocked|unblocked|session_ended
     actor: str
     changes: dict[str, Any]
     timestamp: datetime
+    session_id: str | None = None  # Amplifier session that triggered this event
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
-        return {
+        result = {
             "id": self.id,
             "issue_id": self.issue_id,
             "event_type": self.event_type,
@@ -124,6 +126,9 @@ class IssueEvent:
             "changes": self.changes,
             "timestamp": self.timestamp.isoformat(),
         }
+        if self.session_id is not None:
+            result["session_id"] = self.session_id
+        return result
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "IssueEvent":
@@ -135,4 +140,5 @@ class IssueEvent:
             actor=data["actor"],
             changes=data["changes"],
             timestamp=datetime.fromisoformat(data["timestamp"]),
+            session_id=data.get("session_id"),
         )

--- a/modules/issue-manager/tests/test_session_linking.py
+++ b/modules/issue-manager/tests/test_session_linking.py
@@ -1,0 +1,130 @@
+"""Tests for session linking functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from amplifier_module_issue_manager import IssueManager
+
+
+@pytest.fixture
+def temp_dir():
+    """Create temporary directory for tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def manager_with_session(temp_dir):
+    """Create IssueManager with session_id."""
+    return IssueManager(temp_dir, actor="test", session_id="session-abc123")
+
+
+@pytest.fixture
+def manager_no_session(temp_dir):
+    """Create IssueManager without session_id."""
+    return IssueManager(temp_dir, actor="test")
+
+
+def test_session_id_in_events(manager_with_session):
+    """Test that session_id is recorded in events."""
+    issue = manager_with_session.create_issue(title="Test Issue")
+    events = manager_with_session.get_issue_events(issue.id)
+    
+    assert len(events) == 1
+    assert events[0].session_id == "session-abc123"
+    assert events[0].event_type == "created"
+
+
+def test_session_id_none_when_not_set(manager_no_session):
+    """Test that session_id is None when not configured."""
+    issue = manager_no_session.create_issue(title="Test Issue")
+    events = manager_no_session.get_issue_events(issue.id)
+    
+    assert len(events) == 1
+    assert events[0].session_id is None
+
+
+def test_get_issue_sessions_single_session(manager_with_session):
+    """Test get_issue_sessions with single session."""
+    issue = manager_with_session.create_issue(title="Test Issue")
+    manager_with_session.update_issue(issue.id, status="in_progress")
+    
+    result = manager_with_session.get_issue_sessions(issue.id)
+    
+    assert result["issue_id"] == issue.id
+    assert result["linked_sessions"] == ["session-abc123"]
+    assert result["session_count"] == 1
+    assert "session-abc123" in result["events_by_session"]
+    assert "created" in result["events_by_session"]["session-abc123"]
+    assert "updated" in result["events_by_session"]["session-abc123"]
+
+
+def test_get_issue_sessions_multiple_sessions(temp_dir):
+    """Test get_issue_sessions with multiple sessions."""
+    # First session creates the issue
+    manager1 = IssueManager(temp_dir, actor="test", session_id="session-111")
+    issue = manager1.create_issue(title="Test Issue")
+    
+    # Second session updates the issue
+    manager2 = IssueManager(temp_dir, actor="test", session_id="session-222")
+    manager2.update_issue(issue.id, status="in_progress")
+    
+    # Third session closes the issue
+    manager3 = IssueManager(temp_dir, actor="test", session_id="session-333")
+    manager3.close_issue(issue.id)
+    
+    result = manager3.get_issue_sessions(issue.id)
+    
+    assert result["session_count"] == 3
+    assert sorted(result["linked_sessions"]) == ["session-111", "session-222", "session-333"]
+    assert "created" in result["events_by_session"]["session-111"]
+    assert "updated" in result["events_by_session"]["session-222"]
+    assert "closed" in result["events_by_session"]["session-333"]
+
+
+def test_get_issue_sessions_nonexistent_issue(manager_with_session):
+    """Test get_issue_sessions with nonexistent issue."""
+    with pytest.raises(ValueError, match="Issue not found"):
+        manager_with_session.get_issue_sessions("nonexistent-id")
+
+
+def test_get_issue_sessions_no_sessions(manager_no_session):
+    """Test get_issue_sessions when no sessions recorded."""
+    issue = manager_no_session.create_issue(title="Test Issue")
+    
+    result = manager_no_session.get_issue_sessions(issue.id)
+    
+    assert result["session_count"] == 0
+    assert result["linked_sessions"] == []
+
+
+def test_emit_session_ended(manager_with_session):
+    """Test emitting session_ended event."""
+    issue = manager_with_session.create_issue(title="Test Issue")
+    manager_with_session.update_issue(issue.id, status="in_progress")
+    
+    manager_with_session.emit_session_ended(issue.id)
+    
+    events = manager_with_session.get_issue_events(issue.id)
+    session_ended_events = [e for e in events if e.event_type == "session_ended"]
+    
+    assert len(session_ended_events) == 1
+    assert session_ended_events[0].session_id == "session-abc123"
+
+
+def test_emit_session_ended_nonexistent_issue(manager_with_session):
+    """Test emit_session_ended silently ignores nonexistent issues."""
+    # Should not raise - silently ignores
+    manager_with_session.emit_session_ended("nonexistent-id")
+
+
+def test_session_linking_hint(manager_with_session):
+    """Test that get_issue_sessions returns helpful hint."""
+    issue = manager_with_session.create_issue(title="Test Issue")
+    
+    result = manager_with_session.get_issue_sessions(issue.id)
+    
+    assert "hint" in result
+    assert "amplifier session resume" in result["hint"]

--- a/modules/tool-issue/amplifier_module_tool_issue/__init__.py
+++ b/modules/tool-issue/amplifier_module_tool_issue/__init__.py
@@ -54,6 +54,9 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
     config = config or {}
     actor = config.get("actor", "assistant")
 
+    # Get session_id from coordinator config for session linking
+    session_id = coordinator.config.get("session_id")
+
     # Get base directory with ~ expansion
     base_dir = Path(config.get("data_dir", "~/.amplifier/projects")).expanduser()
 
@@ -68,8 +71,8 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
     if config.get("auto_create_dir", True):
         data_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create tool with embedded IssueManager
-    tool = IssueTool(coordinator, data_dir=data_dir, actor=actor)
+    # Create tool with embedded IssueManager and session linking
+    tool = IssueTool(coordinator, data_dir=data_dir, actor=actor, session_id=session_id)
     await coordinator.mount("tools", tool, name=tool.name)
-    logger.info(f"Mounted issue management tool with data_dir={data_dir}")
+    logger.info(f"Mounted issue management tool with data_dir={data_dir}, session_id={session_id}")
     return


### PR DESCRIPTION
## Summary

Add session linking to the issues bundle, closing the feature gap with the beads bundle. This enables tracking which Amplifier sessions have touched each issue, so users can resume sessions for follow-up questions with full context.

## Changes Made

### Core Changes
- **models.py** - Added `session_id: str | None` field to `IssueEvent` dataclass
- **manager.py** - Added session_id tracking:
  - Constructor accepts `session_id` parameter
  - `_emit_event()` includes session_id in events
  - New `get_issue_sessions(issue_id)` method to query linked sessions
  - New `emit_session_ended(issue_id)` method for session-end marking
- **tool.py** - Added `get_sessions` operation to the tool
- **tool/__init__.py** - Gets session_id from coordinator config and passes to IssueManager

### New Module
- **modules/hook-issue-session-end/** - Hook that marks issues when sessions end

### Documentation & Tests
- **context/issues-instructions.md** - Added documentation for session linking
- **tests/test_session_linking.py** - 9 tests for session linking functionality

## Testing

- All 50 unit tests pass (including 9 new session linking tests)
- Validated in shadow environment with end-to-end integration test

## Intent

Enable users to find which sessions worked on an issue and resume those sessions for follow-up questions, matching the session linking capability in the beads bundle.