### PR TITLE
fix: resolve critical bugs in hooks, tool schema, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ hooks:
       priority: 100
       max_auto_iterations: 10
       inject_role: system
+
+  - module: hook-issue-session-end
+    source: git+https://github.com/microsoft/amplifier-bundle-issues@main#subdirectory=modules/hook-issue-session-end
+    config:
+      priority: 90
 ```
 
 Then add instructions in your bundle context similar to what is found in the [bundle.md](./bundle.md).
@@ -107,10 +112,10 @@ The issue_manager tool supports:
 - **get** - Show issue details
 - **update** - Change status, priority, blocking notes
 - **close** - Mark complete with reason
+- **add_dependency** - Link issues with dependencies
+- **remove_dependency** - Remove dependency links
 - **get_ready** - Find work with no blockers
 - **get_blocked** - See blocked issues
-- **add_dep** - Link issues with dependencies
-- **remove_dep** - Remove dependency links
 - **get_sessions** - Get all Amplifier sessions linked to an issue
 
 ## Issue States
@@ -119,6 +124,8 @@ The issue_manager tool supports:
 - **in_progress** - Actively being worked on
 - **blocked** - Waiting on dependencies
 - **closed** - Completed
+- **completed** - Done (alias: `done`)
+- **pending_user_input** - Waiting for user response (alias: `waiting`)
 
 ## Session Linking
 

--- a/behaviors/issues.yaml
+++ b/behaviors/issues.yaml
@@ -34,6 +34,11 @@ hooks:
       max_auto_iterations: 10
       inject_role: system
 
+  - module: hook-issue-session-end
+    source: git+https://github.com/microsoft/amplifier-bundle-issues@main#subdirectory=modules/hook-issue-session-end
+    config:
+      priority: 90
+
 context:
   include:
     - issues:context/issues-instructions.md

--- a/context/issues-instructions.md
+++ b/context/issues-instructions.md
@@ -81,8 +81,19 @@ The issue_manager tool supports:
 - **get** - Get details of a specific issue (params: issue_id)
 - **update** - Update issue fields (params: issue_id, status, priority, blocking_notes)
 - **close** - Mark issue as complete (params: issue_id, reason)
+- **add_dependency** - Link issues with dependencies (params: from_id, to_id, dep_type)
+- **remove_dependency** - Remove dependency links (params: from_id, to_id)
 - **get_ready** - Get issues ready to work on (params: limit, assignee, priority)
 - **get_blocked** - Get blocked issues
 - **get_sessions** - Get all sessions linked to an issue (params: issue_id)
+
+## Issue Statuses
+
+- **open** - Created, not yet started
+- **in_progress** - Actively being worked on
+- **blocked** - Waiting on dependencies
+- **closed** - Completed
+- **completed** - Done (alias: `done`)
+- **pending_user_input** - Waiting for user response (alias: `waiting`)
 
 Remember: You're working autonomously through a persistent issue queue. Use the issue_manager tool to check for ready work before asking what to do next.

--- a/modules/hook-issue-auto-work/amplifier_module_hook_issue_auto_work/__init__.py
+++ b/modules/hook-issue-auto-work/amplifier_module_hook_issue_auto_work/__init__.py
@@ -55,13 +55,18 @@ class IssueAutoWorkHook:
         self.priority = config.get("priority", 100)
         self.max_auto_iterations = config.get("max_auto_iterations", 10)
         self.inject_role = config.get("inject_role", "system")
-        
+
         # Track auto-work iterations to prevent infinite loops
         self.auto_iteration_count = 0
 
     def register(self, hooks):
         """Register hook on PROMPT_COMPLETE event."""
-        hooks.register("prompt:complete", self.on_prompt_complete, priority=self.priority, name="hook-issue-auto-work")
+        hooks.register(
+            "prompt:complete",
+            self.on_prompt_complete,
+            priority=self.priority,
+            name="hook-issue-auto-work",
+        )
 
     async def on_prompt_complete(self, event: str, data: dict[str, Any]) -> HookResult:
         """Check for ready issues after each turn and continue working if found.
@@ -76,19 +81,21 @@ class IssueAutoWorkHook:
         # Check if issue_manager tool is available
         tools = getattr(self.coordinator, "tools", {})
         issue_manager_tool = None
-        
+
         for tool_name, tool in tools.items():
             if "issue" in tool_name.lower():
                 issue_manager_tool = tool
                 break
-        
+
         if not issue_manager_tool:
-            logger.debug("hook-issue-auto-work: issue_manager tool not available, skipping")
+            logger.debug(
+                "hook-issue-auto-work: issue_manager tool not available, skipping"
+            )
             return HookResult(action="continue")
 
         # Check for iteration limit to prevent infinite loops
         self.auto_iteration_count += 1
-        
+
         if self.auto_iteration_count >= self.max_auto_iterations:
             logger.info(
                 f"hook-issue-auto-work: Reached max auto iterations ({self.max_auto_iterations}), "
@@ -101,12 +108,11 @@ class IssueAutoWorkHook:
         try:
             # Call issue_manager to get ready issues
             result = await issue_manager_tool.execute(
-                operation="get_ready",
-                params={"limit": 5}
+                {"operation": "get_ready", "params": {"limit": 5}}
             )
-            
-            ready_issues = result.get("issues", [])
-            
+
+            ready_issues = result.get("ready_issues", [])
+
             if not ready_issues:
                 logger.debug("hook-issue-auto-work: No ready issues found")
                 # Reset counter when no work left
@@ -115,12 +121,12 @@ class IssueAutoWorkHook:
 
             # Format ready issues for context injection
             issues_text = self._format_ready_issues(ready_issues)
-            
+
             logger.info(
                 f"hook-issue-auto-work: Found {len(ready_issues)} ready issues, "
                 f"injecting context to continue work (iteration {self.auto_iteration_count}/{self.max_auto_iterations})"
             )
-            
+
             # Inject context to tell assistant to keep working
             context_message = (
                 f"<system-reminder>\n"
@@ -132,7 +138,7 @@ class IssueAutoWorkHook:
                 f"Only stop and present to the user when ALL issues are completed or blocked.\n"
                 f"</system-reminder>"
             )
-            
+
             return HookResult(
                 action="inject_context",
                 context_injection=context_message,
@@ -140,7 +146,7 @@ class IssueAutoWorkHook:
                 ephemeral=True,  # Don't store in history
                 suppress_output=True,  # Don't show to user
             )
-            
+
         except Exception as e:
             logger.error(f"hook-issue-auto-work: Error checking for ready issues: {e}")
             # Don't block on errors
@@ -161,7 +167,7 @@ class IssueAutoWorkHook:
             title = issue.get("title", "No title")
             priority = issue.get("priority", 2)
             issue_type = issue.get("issue_type", "task")
-            
+
             # Priority indicators
             priority_indicator = {
                 0: "🔴",  # Critical
@@ -170,7 +176,7 @@ class IssueAutoWorkHook:
                 3: "🟢",  # Low
                 4: "⚪",  # Deferred
             }.get(priority, "🟡")
-            
+
             lines.append(f"{priority_indicator} #{issue_id} [{issue_type}] {title}")
-        
+
         return "\n".join(lines)

--- a/modules/hook-issue-session-start/amplifier_module_hook_issue_session_start/__init__.py
+++ b/modules/hook-issue-session-start/amplifier_module_hook_issue_session_start/__init__.py
@@ -205,7 +205,9 @@ class IssueSessionStartHook:
             return []
 
         try:
-            result = await issue_tool.execute(operation="list", params={"status": "open"})
+            result = await issue_tool.execute(
+                {"operation": "list", "params": {"status": "open"}}
+            )
             return result.get("issues", [])
         except Exception as e:
             logger.debug(f"hook-issue-session-start: Error getting issues: {e}")

--- a/modules/issue-manager/amplifier_module_issue_manager/__init__.py
+++ b/modules/issue-manager/amplifier_module_issue_manager/__init__.py
@@ -34,16 +34,13 @@ async def mount(coordinator, config: dict | None = None):
     data_dir = Path(config.get("data_dir", ".amplifier/issues"))
     actor = config.get("actor", "system")
 
-    logger.info(f"DEBUG mount(): Creating IssueManager with data_dir={data_dir}")
+    logger.debug(f"mount(): Creating IssueManager with data_dir={data_dir}")
 
     if config.get("auto_create_dir", True):
         data_dir.mkdir(parents=True, exist_ok=True)
 
     issue_manager = IssueManager(data_dir, actor=actor)
-    logger.info(f"DEBUG mount(): IssueManager instance created: {issue_manager}")
-    logger.info("DEBUG mount(): About to call coordinator.mount('issue-manager', issue_manager)")
     await coordinator.mount("issue-manager", issue_manager)
-    logger.info("DEBUG mount(): After coordinator.mount, checking result...")
-    logger.info(f"DEBUG mount(): coordinator.get('issue-manager') = {coordinator.get('issue-manager')}")
+    logger.debug("mount(): IssueManager mounted successfully")
 
     return

--- a/modules/issue-manager/amplifier_module_issue_manager/algorithms.py
+++ b/modules/issue-manager/amplifier_module_issue_manager/algorithms.py
@@ -63,7 +63,7 @@ def get_blocked_issues(index: IssueIndex) -> list[tuple[Issue, list[Issue]]]:
     blocked = []
 
     for issue in index.issues.values():
-        if issue.status == "closed":
+        if issue.status in ("closed", "completed"):
             continue
 
         blocker_ids = index.get_blockers(issue.id)
@@ -71,7 +71,7 @@ def get_blocked_issues(index: IssueIndex) -> list[tuple[Issue, list[Issue]]]:
 
         for blocker_id in blocker_ids:
             blocker = index.get_issue(blocker_id)
-            if blocker and blocker.status != "closed":
+            if blocker and blocker.status not in ("closed", "completed"):
                 open_blockers.append(blocker)
 
         if open_blockers:

--- a/modules/tool-issue/amplifier_module_tool_issue/tool.py
+++ b/modules/tool-issue/amplifier_module_tool_issue/tool.py
@@ -67,6 +67,7 @@ class IssueTool:
                         "update",
                         "close",
                         "add_dependency",
+                        "remove_dependency",
                         "get_ready",
                         "get_blocked",
                         "get_sessions",
@@ -186,6 +187,8 @@ class IssueTool:
                 result = await self._close_issue(params)
             elif operation == "add_dependency":
                 result = await self._add_dependency(params)
+            elif operation == "remove_dependency":
+                result = await self._remove_dependency(params)
             elif operation == "get_ready":
                 result = await self._get_ready_issues(params)
             elif operation == "get_blocked":
@@ -300,6 +303,15 @@ class IssueTool:
         """Add a dependency between issues."""
         dep = self.issue_manager.add_dependency(**params)
         return {"dependency": dep.to_dict()}
+
+    async def _remove_dependency(self, params: dict) -> dict:
+        """Remove a dependency between issues."""
+        from_id = params.get("from_id")
+        to_id = params.get("to_id")
+        if not from_id or not to_id:
+            raise ValueError("from_id and to_id are required")
+        self.issue_manager.remove_dependency(from_id, to_id)
+        return {"removed": True, "from_id": from_id, "to_id": to_id}
 
     async def _get_ready_issues(self, params: dict) -> dict:
         """Get issues that are ready to work on (no blockers)."""


### PR DESCRIPTION
## Summary

Fixes 6 bugs/gaps discovered during a comprehensive audit of the issues bundle, plus documentation updates.

## Bug Fixes

- **Auto-work hook completely broken** — `hook-issue-auto-work` had two compounding bugs: (1) called `execute()` with keyword args instead of a single dict matching `IssueTool.execute(input: dict)`, and (2) read `result.get("issues")` but the tool returns `"ready_issues"`. The autonomous queue loop was silently non-functional.

- **Session-start hook broken** — `hook-issue-session-start` had the same calling convention mismatch: `execute(operation=..., params=...)` instead of `execute({"operation": ..., "params": ...})`.

- **`get_blocked_issues` inconsistent with `get_ready_issues`** — `get_blocked_issues()` only excluded `status == "closed"` but `get_ready_issues()` excluded `status not in ("closed", "completed")`. A blocker with status `completed` would show as blocking in one view but not the other. Both now use the same resolved status set.

## Missing Wiring

- **`hook-issue-session-end` not registered** — The module was fully implemented but absent from `behaviors/issues.yaml`. Session boundary events now fire at priority 90.

## Missing Feature

- **`remove_dependency` not exposed in tool** — `IssueManager.remove_dependency()` existed but had no corresponding operation in the tool's schema enum or dispatch. Now accessible to the AI.

## Code Quality

- **Debug log spam** — Removed 5 `logger.info("DEBUG ...")` statements in issue-manager mount, replaced with 2 proper `logger.debug()` calls.

## Documentation

- **README.md** — Fixed operation names (`add_dep`/`remove_dep` to `add_dependency`/`remove_dependency`), added `completed` and `pending_user_input` to Issue States, added `hook-issue-session-end` to manual configuration example.
- **context/issues-instructions.md** — Added `add_dependency`/`remove_dependency` to operations list, added Issue Statuses section documenting all 6 statuses.

## Testing

All 61 existing tests pass.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)